### PR TITLE
Register mime type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     jsonapi_parameters (0.1.0)
+      actionpack (>= 4.1.8)
       activesupport (>= 4.1.8)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jsonapi_parameters (0.1.0)
+    jsonapi_parameters (0.2.0)
       actionpack (>= 4.1.8)
       activesupport (>= 4.1.8)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ If the input is in a different convention than `:snake`, you should specify that
  
  * by a global setting: `JsonApi::Parameters.ensure_underscore_translation = true` 
  * while calling `.jsonapify`, for instance: `.jsonapify(params, naming_convention: :camel)`. **The value does not really matter, as anything different than `:snake` will result in deep keys transformation provided by [ActiveSupport](https://apidock.com/rails/v4.1.8/Hash/deep_transform_keys).**
+ 
+## Mime Type
+
+As [stated in the JSON:API specification](https://jsonapi.org/#mime-types) correct mime type for JSON:API input should be [`application/vnd.api+json`](http://www.iana.org/assignments/media-types/application/vnd.api+json). 
+
+This gems intention is to make input consumption as easy as possible. Hence, it [registers this mime type for you](lib/jsonapi_parameters/core_ext/action_dispatch/http/mime_type.rb). 
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/jsonapi_parameters.gemspec
+++ b/jsonapi_parameters.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'activesupport', '>= 4.1.8'
+  spec.add_dependency 'actionpack', '>= 4.1.8'
 
   spec.add_development_dependency 'json', '~> 2.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3.13'

--- a/lib/jsonapi_parameters/core_ext.rb
+++ b/lib/jsonapi_parameters/core_ext.rb
@@ -1,1 +1,2 @@
 require_relative 'core_ext/action_controller/parameters'
+require_relative 'core_ext/action_dispatch/http/mime_type'

--- a/lib/jsonapi_parameters/core_ext/action_dispatch/http/mime_type.rb
+++ b/lib/jsonapi_parameters/core_ext/action_dispatch/http/mime_type.rb
@@ -1,0 +1,9 @@
+require 'action_dispatch/http/mime_type'
+
+API_MIME_TYPES = %w(
+  application/vnd.api+json
+  text/x-json
+  application/json
+).freeze
+
+Mime::Type.register API_MIME_TYPES.first, :json, API_MIME_TYPES

--- a/lib/jsonapi_parameters/version.rb
+++ b/lib/jsonapi_parameters/version.rb
@@ -1,3 +1,3 @@
 module JsonApi::Parameters
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/lib/jsonapi_parameters/mime_type_spec.rb
+++ b/spec/lib/jsonapi_parameters/mime_type_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Mime::Type do # rubocop:disable RSpec/FilePath
+  result = described_class.lookup_by_extension(:json).instance_variable_get(:@synonyms)
+
+  it 'includes JSON:API application/vnd.api+json mime type registered as json' do
+    expect(result.include?('application/vnd.api+json')).to eq(true)
+  end
+
+  it 'includes standard application/json mime type registered as json' do
+    expect(result.include?('application/json')).to eq(true)
+  end
+end


### PR DESCRIPTION
Registers JSON:API mime type along with the standard ones.

Should resolve #8 