### PR TITLE
Handle to-many relationship without included tree

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,9 @@ Metrics/BlockLength:
 Metrics/AbcSize:
   Max: 23
 Metrics/CyclomaticComplexity:
-  Max: 7
+  Max: 8
+Metrics/PerceivedComplexity:
+  Max: 8
 Metrics/LineLength:
   Max: 150
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jsonapi_parameters (0.2.0)
+    jsonapi_parameters (0.3.0)
       actionpack (>= 4.1.8)
       activesupport (>= 4.1.8)
 

--- a/lib/jsonapi_parameters.rb
+++ b/lib/jsonapi_parameters.rb
@@ -2,3 +2,5 @@ require 'jsonapi_parameters/parameters'
 require 'jsonapi_parameters/translator'
 require 'jsonapi_parameters/core_ext'
 require 'jsonapi_parameters/version'
+
+require 'active_support/inflector'

--- a/lib/jsonapi_parameters/translator.rb
+++ b/lib/jsonapi_parameters/translator.rb
@@ -1,4 +1,6 @@
 module JsonApi::Parameters
+  include ActiveSupport::Inflector
+
   def jsonapify(params, naming_convention: :snake)
     jsonapi_translate(params, naming_convention: naming_convention)
   end
@@ -92,7 +94,7 @@ module JsonApi::Parameters
       end
     end
 
-    key = with_inclusion ? "#{relationship_key}_attributes".to_sym : "#{relationship_key}_ids".to_sym
+    key = with_inclusion ? "#{pluralize(relationship_key)}_attributes".to_sym : "#{singularize(relationship_key)}_ids".to_sym
 
     [key, vals]
   end

--- a/lib/jsonapi_parameters/translator.rb
+++ b/lib/jsonapi_parameters/translator.rb
@@ -101,16 +101,17 @@ module JsonApi::Parameters
 
   def handle_to_one_relation(relationship_key, relationship_value)
     related_id = relationship_value.dig(:id)
-    related_type = relationship_key.to_s
+    related_type = relationship_value.dig(:type)
 
     included_object = find_included_object(
       related_id: related_id, related_type: related_type
-    )
+    ) || {}
 
-    return ["#{related_type.singularize}_id".to_sym, related_id] if included_object.nil?
+    return ["#{singularize(relationship_key)}_id".to_sym, related_id] if included_object.empty?
 
     included_object.delete(:type)
-    ["#{related_type.singularize}_attributes".to_sym, included_object]
+    included_object = included_object[:attributes].merge(id: related_id)
+    ["#{singularize(relationship_key)}_attributes".to_sym, included_object]
   end
 
   def find_included_object(related_id:, related_type:)

--- a/lib/jsonapi_parameters/version.rb
+++ b/lib/jsonapi_parameters/version.rb
@@ -1,5 +1,5 @@
 module JsonApi
   module Parameters
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -11,58 +11,58 @@ module JsonApi::Parameters::Testing
       ],
       'single root, single relationship, multiple related resources' => [
         {
-          :data => {
-            :type => "contract",
-            :attributes => {
-              :total_amount => "40.0",
-              :start_date => "2018-10-18"
+          data: {
+            type: "contract",
+            attributes: {
+              total_amount: "40.0",
+              start_date: "2018-10-18"
             },
-            :relationships => {
-              :products => {
-                :data => [
+            relationships: {
+              products: {
+                data: [
                   {
-                    :id => "4", :type => "product"
+                    id: "4", type: "product"
                   }, {
-                    :id => "5", :type => "product"
+                    id: "5", type: "product"
                   }, {
-                    :id => "6", :type => "product"
+                    id: "6", type: "product"
                   }
                 ]
               },
-              :customer => {
-                :data => {
-                  :id => "1", :type => "customer"
+              customer: {
+                data: {
+                  id: "1", type: "customer"
                 }
               }
             }
           },
-          :included => [
+          included: [
             {
-              :id => "4",
-              :type => "product",
-              :attributes => {
-                :category => "first_category",
-                :amount => "15.0",
-                :name => "First product",
-                :note => ""
+              id: "4",
+              type: "product",
+              attributes: {
+                category: "first_category",
+                amount: "15.0",
+                name: "First product",
+                note: ""
               }
             },
             {
-              :id => "5",
-              :type => "product",
-              :attributes => {
-                :category => "first_category",
-                :amount => "10.0",
-                :name => "Second Product",
+              id: "5",
+              type: "product",
+              attributes: {
+                category: "first_category",
+                amount: "10.0",
+                name: "Second Product",
               }
             },
             {
-              :id => "6",
-              :type => "product",
-              :attributes => {
-                :category => "second_category",
-                :amount => "15.0",
-                :name => "Third Product",
+              id: "6",
+              type: "product",
+              attributes: {
+                category: "second_category",
+                amount: "15.0",
+                name: "Third Product",
               }
             }
           ]
@@ -75,22 +75,22 @@ module JsonApi::Parameters::Testing
             products_attributes: [
               {
                 id: '4',
-                :category => "first_category",
-                :amount => "15.0",
-                :name => "First product",
+                category: "first_category",
+                amount: "15.0",
+                name: "First product",
                 note: ''
               },
               {
                 id: '5',
-                :category => "first_category",
-                :amount => "10.0",
-                :name => "Second Product"
+                category: "first_category",
+                amount: "10.0",
+                name: "Second Product"
               },
               {
                 id: '6',
-                :category => "second_category",
-                :amount => "15.0",
-                :name => "Third Product"
+                category: "second_category",
+                amount: "15.0",
+                name: "Third Product"
               }
             ]
           }
@@ -182,29 +182,29 @@ module JsonApi::Parameters::Testing
       'relationships without included (issue #13 - https://github.com/visualitypl/jsonapi_parameters/issues/13)' => [
         {
           data: {
-              type: 'movies',
-              attributes: {
-                title: 'The Terminator',
-                released_at: '1984-10-26',
-                runtime: 107,
-                content_rating: 'restricted',
-                storyline: 'A seemingly indestructible android is sent from 2029 to 1984 to assassinate a waitress, whose unborn son will lead humanity in a war against the machines, while a soldier from that war is sent to protect her at all costs.',
-                budget: 6400000
-              },
-              relationships: {
-                genres: {
-                  data: [
-                    {
-                      id: 74, type: 'genres'
-                    }
-                  ]
-                },
-                director: {
-                  data: {
-                    id: 682, type: 'directors'
+            type: 'movies',
+            attributes: {
+              title: 'The Terminator',
+              released_at: '1984-10-26',
+              runtime: 107,
+              content_rating: 'restricted',
+              storyline: 'A seemingly indestructible android is sent from 2029 to 1984 to assassinate a waitress, whose unborn son will lead humanity in a war against the machines, while a soldier from that war is sent to protect her at all costs.',
+              budget: 6400000
+            },
+            relationships: {
+              genres: {
+                data: [
+                  {
+                    id: 74, type: 'genres'
                   }
+                ]
+              },
+              director: {
+                data: {
+                  id: 682, type: 'directors'
                 }
               }
+            }
             }
         },
         {

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -219,6 +219,56 @@ module JsonApi::Parameters::Testing
             genre_ids: [74]
           }
         }
+      ],
+      'relationships with included director (issue #13 - https://github.com/visualitypl/jsonapi_parameters/issues/13)' => [
+        {
+          data: {
+            type: 'movies',
+            attributes: {
+              title: 'The Terminator',
+              released_at: '1984-10-26',
+              runtime: 107,
+              content_rating: 'restricted',
+              storyline: 'A seemingly indestructible android is sent from 2029 to 1984 to assassinate a waitress, whose unborn son will lead humanity in a war against the machines, while a soldier from that war is sent to protect her at all costs.',
+              budget: 6400000
+            },
+            relationships: {
+              genres: {
+                data: [
+                  {
+                    id: 74, type: 'genres'
+                  }
+                ]
+              },
+              director: {
+                data: {
+                  id: 682, type: 'directors'
+                }
+              }
+            }
+          },
+          included: [
+            {
+              type: 'directors',
+              id: 682,
+              attributes: {
+                name: 'Some guy'
+              }
+            }
+          ]
+        },
+        {
+          movie: {
+            title: 'The Terminator',
+            released_at: '1984-10-26',
+            runtime: 107,
+            content_rating: 'restricted',
+            storyline: 'A seemingly indestructible android is sent from 2029 to 1984 to assassinate a waitress, whose unborn son will lead humanity in a war against the machines, while a soldier from that war is sent to protect her at all costs.',
+            budget: 6400000,
+            director_attributes: { id: 682, name: 'Some guy' },
+            genre_ids: [74]
+          }
+        }
       ]
     ],
     'PATCH update payloads' => [

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -216,7 +216,7 @@ module JsonApi::Parameters::Testing
             storyline: 'A seemingly indestructible android is sent from 2029 to 1984 to assassinate a waitress, whose unborn son will lead humanity in a war against the machines, while a soldier from that war is sent to protect her at all costs.',
             budget: 6400000,
             director_id: 682,
-            genres_ids: [74]
+            genre_ids: [74]
           }
         }
       ]

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -11,90 +11,90 @@ module JsonApi::Parameters::Testing
       ],
       'single root, single relationship, multiple related resources' => [
         {
-         :data => {
-           :type => "contract",
-           :attributes => {
-             :total_amount=>"40.0",
-             :start_date=>"2018-10-18"
-           },
-           :relationships=>{
-             :products=>{
-               :data=>[
-                 {
-                   :id=>"4", :type=>"product"
-                 }, {
-                   :id=>"5", :type=>"product"
-                 }, {
-                   :id=>"6", :type=>"product"
-                 }
-               ]
-             },
-             :customer=>{
-               :data=>{
-                 :id=>"1", :type=>"customer"
-               }
-             }
-           }
-         },
-         :included=>[
-           {
-             :id=>"4",
-             :type=>"product",
-             :attributes=>{
-               :category=>"first_category",
-               :amount=>"15.0",
-               :name=>"First product",
-               :note=>""
-             }
-           },
-           {
-             :id=>"5",
-             :type=>"product",
-             :attributes=>{
-               :category=>"first_category",
-               :amount=>"10.0",
-               :name=>"Second Product",
-             }
-           },
-           {
-             :id=>"6",
-             :type=>"product",
-             :attributes=>{
-               :category=>"second_category",
-               :amount=>"15.0",
-               :name=>"Third Product",
-             }
-           }
-         ]
-       },
-       {
-         contract: {
-           start_date: '2018-10-18',
-           total_amount: '40.0',
-           customer_id: '1',
-           products_attributes: [
-             {
-               id: '4',
-               :category=>"first_category",
-               :amount=>"15.0",
-               :name=>"First product",
-               note: ''
-             },
-             {
-               id: '5',
-               :category=>"first_category",
-               :amount=>"10.0",
-               :name=>"Second Product"
-             },
-             {
-               id: '6',
-               :category=>"second_category",
-               :amount=>"15.0",
-               :name=>"Third Product"
-             }
-           ]
-         }
-       }
+          :data => {
+            :type => "contract",
+            :attributes => {
+              :total_amount => "40.0",
+              :start_date => "2018-10-18"
+            },
+            :relationships => {
+              :products => {
+                :data => [
+                  {
+                    :id => "4", :type => "product"
+                  }, {
+                    :id => "5", :type => "product"
+                  }, {
+                    :id => "6", :type => "product"
+                  }
+                ]
+              },
+              :customer => {
+                :data => {
+                  :id => "1", :type => "customer"
+                }
+              }
+            }
+          },
+          :included => [
+            {
+              :id => "4",
+              :type => "product",
+              :attributes => {
+                :category => "first_category",
+                :amount => "15.0",
+                :name => "First product",
+                :note => ""
+              }
+            },
+            {
+              :id => "5",
+              :type => "product",
+              :attributes => {
+                :category => "first_category",
+                :amount => "10.0",
+                :name => "Second Product",
+              }
+            },
+            {
+              :id => "6",
+              :type => "product",
+              :attributes => {
+                :category => "second_category",
+                :amount => "15.0",
+                :name => "Third Product",
+              }
+            }
+          ]
+        },
+        {
+          contract: {
+            start_date: '2018-10-18',
+            total_amount: '40.0',
+            customer_id: '1',
+            products_attributes: [
+              {
+                id: '4',
+                :category => "first_category",
+                :amount => "15.0",
+                :name => "First product",
+                note: ''
+              },
+              {
+                id: '5',
+                :category => "first_category",
+                :amount => "10.0",
+                :name => "Second Product"
+              },
+              {
+                id: '6',
+                :category => "second_category",
+                :amount => "15.0",
+                :name => "Third Product"
+              }
+            ]
+          }
+        }
       ],
       'https://jsonapi.org/format/#crud example' => [
         {
@@ -178,66 +178,107 @@ module JsonApi::Parameters::Testing
             ]
           }
         }
-      ]
-    ],
-    'PATCH update payloads' => [
-      'https://jsonapi.org/format/#crud example (modified, multiple photographers)' => [
+      ],
+      'relationships without included (issue #13 - https://github.com/visualitypl/jsonapi_parameters/issues/13)' => [
         {
           data: {
-            type: 'photos',
-            attributes: {
-              title: 'Ember Hamster',
-              src: 'http://example.com/images/productivity.png'
-            },
-            relationships: {
-              photographers: {
-                data: [
-                  {
-                    type: 'people',
-                    id: 9
-                  },
-                  {
-                    type: 'people',
-                    id: 10
+              type: 'movies',
+              attributes: {
+                title: 'The Terminator',
+                released_at: '1984-10-26',
+                runtime: 107,
+                content_rating: 'restricted',
+                storyline: 'A seemingly indestructible android is sent from 2029 to 1984 to assassinate a waitress, whose unborn son will lead humanity in a war against the machines, while a soldier from that war is sent to protect her at all costs.',
+                budget: 6400000
+              },
+              relationships: {
+                genres: {
+                  data: [
+                    {
+                      id: 74, type: 'genres'
+                    }
+                  ]
+                },
+                director: {
+                  data: {
+                    id: 682, type: 'directors'
                   }
-                ]
+                }
               }
             }
-          },
-          included: [
-            {
-              type: 'people',
-              id: 10,
-              attributes: {
-                name: 'Some guy'
-              }
-            },
-            {
-              type: 'people',
-              id: 9,
-              attributes: {
-                name: 'Some other guy'
-              }
-            }
-          ]
         },
         {
-          photo: {
-            title: 'Ember Hamster',
-            src: 'http://example.com/images/productivity.png',
-            photographers_attributes: [
-              {
-                id: 9,
-                name: 'Some other guy'
-              },
-              {
-                id: 10,
-                name: 'Some guy'
-              }
-            ]
+          movie: {
+            title: 'The Terminator',
+            released_at: '1984-10-26',
+            runtime: 107,
+            content_rating: 'restricted',
+            storyline: 'A seemingly indestructible android is sent from 2029 to 1984 to assassinate a waitress, whose unborn son will lead humanity in a war against the machines, while a soldier from that war is sent to protect her at all costs.',
+            budget: 6400000,
+            director_id: 682,
+            genres_ids: [74]
           }
         }
       ]
-    ]
+    ],
+    'PATCH update payloads' => [
+        'https://jsonapi.org/format/#crud example (modified, multiple photographers)' => [
+          {
+            data: {
+              type: 'photos',
+              attributes: {
+                title: 'Ember Hamster',
+                src: 'http://example.com/images/productivity.png'
+              },
+              relationships: {
+                photographers: {
+                  data: [
+                    {
+                      type: 'people',
+                      id: 9
+                    },
+                    {
+                      type: 'people',
+                      id: 10
+                    }
+                  ]
+                }
+              }
+            },
+            included: [
+              {
+                type: 'people',
+                id: 10,
+                attributes: {
+                  name: 'Some guy'
+                }
+              },
+              {
+                type: 'people',
+                id: 9,
+                attributes: {
+                  name: 'Some other guy'
+                }
+              }
+            ]
+          },
+          {
+            photo: {
+              title: 'Ember Hamster',
+              src: 'http://example.com/images/productivity.png',
+              photographers_attributes: [
+                {
+                  id: 9,
+                  name: 'Some other guy'
+                },
+                {
+                  id: 10,
+                  name: 'Some guy'
+                }
+              ]
+            }
+          }
+        ]
+      ]
   }
 end


### PR DESCRIPTION
Included tree may or may not be passed (within a compound document),
which means that it may occur that there are to-many relationships
passed that are not present in the `included` tree.

In such scenarios, we should make sure that relationship is translated
in such a manner that it will yield something like:
`genres_ids: [74]`.

Related to #13 [issue](https://github.com/visualitypl/jsonapi_parameters/issues/13).