### PR TITLE
Feature add support nil data relationship removal

### DIFF
--- a/lib/jsonapi_parameters/translator.rb
+++ b/lib/jsonapi_parameters/translator.rb
@@ -41,6 +41,10 @@ module JsonApi::Parameters
                    when Hash
                      handle_to_one_relation(relationship_key, relationship_value)
                    when nil
+                     # Raise error if nil on to-many association.
+                     raise jsonapi_not_implemented_err if pluralize(relationship_key).to_sym == relationship_key
+
+                     # Handle with default hash.
                      handle_to_one_relation(relationship_key, {})
                    else
                      raise jsonapi_not_implemented_err

--- a/lib/jsonapi_parameters/translator.rb
+++ b/lib/jsonapi_parameters/translator.rb
@@ -35,12 +35,13 @@ module JsonApi::Parameters
     jsonapi_unsafe_params.tap do |param|
       jsonapi_relationships.each do |relationship_key, relationship_value|
         relationship_value = relationship_value[:data]
-
         key, val = case relationship_value
                    when Array
                      handle_to_many_relation(relationship_key, relationship_value)
                    when Hash
                      handle_to_one_relation(relationship_key, relationship_value)
+                   when nil
+                     handle_to_one_relation(relationship_key, {})
                    else
                      raise jsonapi_not_implemented_err
                    end

--- a/lib/jsonapi_parameters/translator.rb
+++ b/lib/jsonapi_parameters/translator.rb
@@ -41,11 +41,7 @@ module JsonApi::Parameters
                    when Hash
                      handle_to_one_relation(relationship_key, relationship_value)
                    when nil
-                     # Raise error if nil on to-many association.
-                     raise jsonapi_not_implemented_err if pluralize(relationship_key).to_sym == relationship_key
-
-                     # Handle with default hash.
-                     handle_to_one_relation(relationship_key, {})
+                     handle_nil_relation(relationship_key)
                    else
                      raise jsonapi_not_implemented_err
                    end
@@ -117,6 +113,14 @@ module JsonApi::Parameters
     included_object.delete(:type)
     included_object = included_object[:attributes].merge(id: related_id)
     ["#{singularize(relationship_key)}_attributes".to_sym, included_object]
+  end
+
+  def handle_nil_relation(relationship_key)
+    # Graceful fail if nil on to-many association.
+    raise jsonapi_not_implemented_err if pluralize(relationship_key).to_sym == relationship_key
+
+    # Handle with empty hash.
+    handle_to_one_relation(relationship_key, {})
   end
 
   def find_included_object(related_id:, related_type:)

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -339,7 +339,7 @@ module JsonApi::Parameters::Testing
               },
               relationships: {
                 owner: {
-                  data: { }
+                  data: nil
                 }
               }
             }

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -329,6 +329,29 @@ module JsonApi::Parameters::Testing
             }
           }
         ],
+        'https://jsonapi.org/format/#crud-updating-to-many-relationships example (removal, all photographers' => [
+          {
+            data: {
+              type: 'photos',
+              attributes: {
+                title: 'Ember Hamster',
+                src: 'http://example.com/images/productivity.png'
+              },
+              relationships: {
+                photographers: {
+                  data: []
+                }
+              }
+            }
+          },
+          {
+            photo: {
+              title: 'Ember Hamster',
+              src: 'http://example.com/images/productivity.png',
+              photographers_attributes: []
+            }
+          }
+        ],
         'https://jsonapi.org/format/#crud-updating-to-one-relationships example (removal, single author)' => [
           {
             data: {

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -329,7 +329,7 @@ module JsonApi::Parameters::Testing
             }
           }
         ],
-        'https://jsonapi.org/format/#crud-updating-to-many-relationships example (removal, all photographers' => [
+        'https://jsonapi.org/format/#crud-updating-to-many-relationships example (removal, all photographers)' => [
           {
             data: {
               type: 'photos',
@@ -352,7 +352,7 @@ module JsonApi::Parameters::Testing
             }
           }
         ],
-        'https://jsonapi.org/format/#crud-updating-to-one-relationships example (removal, single author)' => [
+        'https://jsonapi.org/format/#crud-updating-to-one-relationships example (removal, single owner)' => [
           {
             data: {
               type: 'account',

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -328,6 +328,29 @@ module JsonApi::Parameters::Testing
               ]
             }
           }
+        ],
+        'https://jsonapi.org/format/#crud-updating-to-one-relationships example (removal, single author)' => [
+          {
+            data: {
+              type: 'account',
+              attributes: {
+                name: 'Bob Loblaw',
+                profile_url: 'http://example.com/images/no-nonsense.png'
+              },
+              relationships: {
+                owner: {
+                  data: { }
+                }
+              }
+            }
+          },
+          {
+            account: {
+              name: 'Bob Loblaw',
+              profile_url: 'http://example.com/images/no-nonsense.png',
+              owner_id: nil
+            }
+          }
         ]
       ]
   }


### PR DESCRIPTION
Hi,
In reference to #18 
I've added two test cases for clearing `to-many` and `to-one` relationships. 

- Adds a nil hash patch for when the relationship is given as nil.
- Adds a catch for graceful failure (according to spec) of nil value to-many relationship patch.

I'm beginning to see the complexity of this. It's hard to tell how to inflect to-many or to-one relationship type. I've gone with pluralisation but this does open the door for edge cases...

i.e. 

```ruby
class Santa
  has_many :reindeer
  # The cheeky bugger. 
end
```

The only way we can really be sure of a relationships type is through `reflect_on_all_associations` but that's not really the job of this gem. 

🤔 Open to ideas here guys.
