### PR TITLE
Enlarge Metrics/ModuleLength to 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,8 @@ Metrics/LineLength:
   Max: 150
   Exclude:
     - 'spec/**/*_spec.rb'
+Metrics/ModuleLength:
+  Max: 120
 Metrics/MethodLength:
   Max: 25
 Style/ClassAndModuleChildren:


### PR DESCRIPTION
Also it may be worth to consider disabling this metric overall as it may
provide more chaos than actual value.