### PR TITLE
Translate data type names

### DIFF
--- a/lib/jsonapi_parameters/translator.rb
+++ b/lib/jsonapi_parameters/translator.rb
@@ -15,7 +15,9 @@ module JsonApi::Parameters
     return params if params.nil? || params.empty?
 
     @jsonapi_unsafe_hash = if naming_convention != :snake || JsonApi::Parameters.ensure_underscore_translation
-                             params.deep_transform_keys { |key| key.to_s.underscore.to_sym }
+                             params = params.deep_transform_keys { |key| key.to_s.underscore.to_sym }
+                             params[:data][:type] = params[:data][:type].underscore if params.dig(:data, :type)
+                             params
                            else
                              params.deep_symbolize_keys
                            end

--- a/spec/lib/jsonapi_parameters/translator_spec.rb
+++ b/spec/lib/jsonapi_parameters/translator_spec.rb
@@ -51,6 +51,7 @@ describe Translator do
             kase.each do |case_name, case_data|
               it "matches #{case_name}" do
                 input, predicted_output = case_data
+                input[:data][:type] = input[:data][:type].camelize
                 input = input.deep_transform_keys { |key| key.to_s.camelize.to_sym }
                 input = ActionController::Parameters.new(input)
 
@@ -70,6 +71,7 @@ describe Translator do
             kase.each do |case_name, case_data|
               it "matches #{case_name}" do
                 input, predicted_output = case_data
+                input[:data][:type] = input[:data][:type].dasherize
                 input = input.deep_transform_keys { |key| key.to_s.dasherize.to_sym }
                 input = ActionController::Parameters.new(input)
 
@@ -136,6 +138,7 @@ describe Translator do
                 JsonApi::Parameters.ensure_underscore_translation = true
 
                 input, predicted_output = case_data
+                input[:data][:type] = input[:data][:type].camelize
                 input = input.deep_transform_keys { |key| key.to_s.camelize.to_sym }
                 input = ActionController::Parameters.new(input)
 
@@ -159,6 +162,7 @@ describe Translator do
                 JsonApi::Parameters.ensure_underscore_translation = true
 
                 input, predicted_output = case_data
+                input[:data][:type] = input[:data][:type].dasherize
                 input = input.deep_transform_keys { |key| key.to_s.dasherize.to_sym }
                 input = ActionController::Parameters.new(input)
 

--- a/spec/support/inputs_outputs_pairs.rb
+++ b/spec/support/inputs_outputs_pairs.rb
@@ -273,6 +273,17 @@ module JsonApi::Parameters::Testing
             genre_ids: [74]
           }
         }
+      ],
+      'long type name' => [
+        {
+          data: {
+            type: 'message_board_threads',
+            attributes: {
+              thread_title: 'Introductory Thread'
+            }
+          }
+        },
+        { message_board_thread: { thread_title: 'Introductory Thread' } }
       ]
     ],
     'PATCH update payloads' => [


### PR DESCRIPTION
As mentioned in #30, I think it would make sense to automatically translate the main data type name as well to underscores. Here is a proof of concept to do that.

This would allow:

```json
{"data": {"type": "messageBoardThread"}}
```

To be accessible as:

```ruby
params.from_jsonapi.require(:message_board_thread)
```

Unfortunately this would be a breaking change because applications using this gem would already expect the data type in the original format so some care should be taken here.

I was wondering about whether I'd need to translate the type names of associated objects and relationships as well but those are never exposed so I figured it's unnecessary. I can add a test case to prove that though if you'd like.