### PR TITLE
Add support for embedding relationships.

### DIFF
--- a/lib/jsonapi_parameters/default_handlers/base_handler.rb
+++ b/lib/jsonapi_parameters/default_handlers/base_handler.rb
@@ -11,6 +11,12 @@ module JsonApi
             @included = included
           end
 
+          def find_embedded_object(relationship:)
+            return if relationship[:attributes].nil? || relationship[:attributes].empty?
+
+            relationship.slice(:attributes)
+          end
+
           def find_included_object(related_id:, related_type:)
             included.find do |included_object_enum|
               included_object_enum[:id] &&
@@ -18,6 +24,10 @@ module JsonApi
                 included_object_enum[:type] &&
                 included_object_enum[:type] == related_type
             end
+          end
+
+          def self.call(key, val, included)
+            new(key, val, included).handle
           end
         end
       end

--- a/lib/jsonapi_parameters/default_handlers/to_many_relation_handler.rb
+++ b/lib/jsonapi_parameters/default_handlers/to_many_relation_handler.rb
@@ -5,45 +5,42 @@ module JsonApi
         class ToManyRelationHandler < BaseHandler
           include ActiveSupport::Inflector
 
-          attr_reader :with_inclusion, :vals, :key
-
           def handle
-            @with_inclusion = !relationship_value.empty?
-
-            prepare_relationship_vals
-
-            generate_key
-
             [key, vals]
           end
 
           private
 
-          def prepare_relationship_vals
-            @vals = relationship_value.map do |relationship|
+          def key
+            @key ||= if with_inclusion
+                       "#{pluralize(relationship_key)}_attributes".to_sym
+                     else
+                       "#{singularize(relationship_key)}_ids".to_sym
+                     end
+          end
+
+          def vals
+            @vals ||= relationship_value.map do |relationship|
               related_id = relationship.dig(:id)
               related_type = relationship.dig(:type)
 
-              included_object = find_included_object(
-                related_id: related_id, related_type: related_type
-              ) || {}
+              included_object =
+                find_embedded_object(relationship: relationship) ||
+                find_included_object(related_id: related_id, related_type: related_type) ||
+                {}
 
-              # If at least one related object has not been found in `included` tree,
-              # we should not attempt to "#{relationship_key}_attributes" but
-              # "#{relationship_key}_ids" instead.
-              @with_inclusion &= !included_object.empty?
-
-              if with_inclusion
-                included_object.delete(:type)
-                included_object[:attributes].merge(id: related_id)
-              else
+              if included_object.empty?
                 relationship.dig(:id)
+              else
+                included_object[:attributes].merge(id: related_id)
               end
             end
           end
 
-          def generate_key
-            @key = (with_inclusion ? "#{pluralize(relationship_key)}_attributes" : "#{singularize(relationship_key)}_ids").to_sym
+          def with_inclusion
+            # If at least one related object has not been found in `included` tree,
+            # all relationship objects are not treated as included
+            @with_inclusion ||= vals.present? && vals.all? { |v| v.kind_of? Hash }
           end
         end
       end

--- a/lib/jsonapi_parameters/handlers.rb
+++ b/lib/jsonapi_parameters/handlers.rb
@@ -8,9 +8,9 @@ module JsonApi
       include DefaultHandlers
 
       DEFAULT_HANDLER_SET = {
-        to_many: ->(k, v, included) { ToManyRelationHandler.new(k, v, included).handle },
-        to_one: ->(k, v, included) { ToOneRelationHandler.new(k, v, included).handle },
-        nil: ->(k, v, included) { NilRelationHandler.new(k, v, included).handle }
+        to_many: ToManyRelationHandler,
+        to_one: ToOneRelationHandler,
+        nil: NilRelationHandler
       }.freeze
 
       module_function

--- a/spec/integration/authors_camel_controller_spec.rb
+++ b/spec/integration/authors_camel_controller_spec.rb
@@ -31,7 +31,7 @@ describe AuthorsCamelController, type: :controller do
       )
     end
 
-    it 'creates an author with posts' do
+    it 'creates an author with included posts' do
       params = {
         data: {
           type: 'authors',
@@ -60,6 +60,54 @@ describe AuthorsCamelController, type: :controller do
             }
           }
         ]
+      }
+
+      post :create, params: params
+
+      expect(jsonapi_response[:data]).to eq(
+        id: '1',
+        type: 'author',
+        attributes: {
+          name: 'John Doe'
+        },
+        relationships: {
+          scissors: { data: nil },
+          posts: {
+            data: [
+              {
+                id: '1',
+                type: 'post'
+              }
+            ]
+          }
+        }
+      )
+      expect(Post.find(1).category_name).to eq('Some category')
+    end
+
+    it 'creates an author with embedded posts' do
+      params = {
+        data: {
+          type: 'authors',
+          attributes: {
+            name: 'John Doe'
+          },
+          relationships: {
+            posts: {
+              data: [
+                {
+                  id: '123',
+                  type: 'post',
+                  attributes: {
+                    title: 'Some title',
+                    body: 'Some body that I used to love',
+                    categoryName: 'Some category'
+                  }
+                }
+              ]
+            }
+          }
+        },
       }
 
       post :create, params: params

--- a/spec/integration/authors_controller_spec.rb
+++ b/spec/integration/authors_controller_spec.rb
@@ -31,7 +31,7 @@ describe AuthorsController, type: :controller do
       )
     end
 
-    it 'creates an author with posts' do
+    it 'creates an author with included posts' do
       params = {
         data: {
           type: 'authors',
@@ -60,6 +60,54 @@ describe AuthorsController, type: :controller do
             }
           }
         ]
+      }
+
+      post :create, params: params
+
+      expect(jsonapi_response[:data]).to eq(
+        id: '1',
+        type: 'author',
+        attributes: {
+          name: 'John Doe'
+        },
+        relationships: {
+          posts: {
+            data: [
+              {
+                id: '1',
+                type: 'post'
+              }
+            ]
+          },
+          scissors: { data: nil }
+        }
+      )
+      expect(Post.find(1).category_name).to eq('Some category')
+    end
+
+    it 'creates an author with embedded posts' do
+      params = {
+        data: {
+          type: 'authors',
+          attributes: {
+            name: 'John Doe'
+          },
+          relationships: {
+            posts: {
+              data: [
+                {
+                  id: '123',
+                  type: 'post',
+                  attributes: {
+                    title: 'Some title',
+                    body: 'Some body that I used to love',
+                    category_name: 'Some category'
+                  }
+                }
+              ]
+            }
+          }
+        }
       }
 
       post :create, params: params

--- a/spec/integration/authors_deprecated_to_jsonapi_controller_spec.rb
+++ b/spec/integration/authors_deprecated_to_jsonapi_controller_spec.rb
@@ -31,7 +31,7 @@ describe AuthorsDeprecatedToJsonapiController, type: :controller do
       )
     end
 
-    it 'creates an author with posts' do
+    it 'creates an author with included posts' do
       params = {
         data: {
           type: 'authors',
@@ -60,6 +60,54 @@ describe AuthorsDeprecatedToJsonapiController, type: :controller do
             }
           }
         ]
+      }
+
+      post :create, params: params
+
+      expect(jsonapi_response[:data]).to eq(
+        id: '1',
+        type: 'author',
+        attributes: {
+          name: 'John Doe'
+        },
+        relationships: {
+          scissors: { data: nil },
+          posts: {
+            data: [
+              {
+                id: '1',
+                type: 'post'
+              }
+            ]
+          }
+        }
+      )
+      expect(Post.find(1).category_name).to eq('Some category')
+    end
+
+    it 'creates an author with embedded posts' do
+      params = {
+        data: {
+          type: 'authors',
+          attributes: {
+            name: 'John Doe'
+          },
+          relationships: {
+            posts: {
+              data: [
+                {
+                  id: '123',
+                  type: 'post',
+                  attributes: {
+                    title: 'Some title',
+                    body: 'Some body that I used to love',
+                    category_name: 'Some category'
+                  }
+                }
+              ]
+            }
+          }
+        }
       }
 
       post :create, params: params


### PR DESCRIPTION
I'm using this gem with Ember.js and [ember-data-save-relationships](https://github.com/psteininger/ember-data-save-relationships) plugin. That add-on sends attributes for relationships under `attributes` parameter instead of `included`. I've added support for getting data from `attributes` and if it's empty, then fallback to `included`.

I've also extracted method to generate relationship key to a separate method so it's easier to customize (i.e. if you don't want to use `accepted_nested_attributes_for`) and slightly refactor default handlers.