### PR TITLE
OS-42 Add ruby300 to circle ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/ruby:2.7.0
+  ruby-300:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:3.0.0
   download-and-persist-cc-test-reporter:
     docker:
         - image: circleci/ruby:2.6.0
@@ -72,6 +76,9 @@ workflows:
       - ruby-270:
           requires:
             - download-and-persist-cc-test-reporter
+      - ruby-300:
+          requires:
+            - download-and-persist-cc-test-reporter
       - upload-test-coverage:
           filters:
             branches:
@@ -81,3 +88,4 @@ workflows:
             - ruby-250
             - ruby-260
             - ruby-270
+            - ruby-300

--- a/jsonapi_parameters.gemspec
+++ b/jsonapi_parameters.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rubocop', '~> 0.62.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.31.0'
-  spec.add_development_dependency 'bundler-audit', '~> 0.6.0'
+  spec.add_development_dependency 'bundler-audit', '~> 0.7.0'
   spec.add_development_dependency 'fast_jsonapi', '~> 1.5'
   spec.add_development_dependency 'loofah', '~> 2.3.1'
   spec.add_development_dependency 'factory_bot', '~> 4.11.1'

--- a/jsonapi_parameters.gemspec
+++ b/jsonapi_parameters.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'json', '~> 2.0'
   spec.add_development_dependency 'sqlite3', '~> 1.4'
   spec.add_development_dependency 'database_cleaner', '~> 1.7.0'
-  spec.add_development_dependency 'rails', '>= 4.1.8'
+  spec.add_development_dependency 'rails', '>= 4.1.8', '< 6.1'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.8.1'
   spec.add_development_dependency 'pry', '~> 0.12.2'

--- a/jsonapi_parameters.gemspec
+++ b/jsonapi_parameters.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rubocop', '~> 0.62.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.31.0'
-  spec.add_development_dependency 'bundler-audit', '~> 0.7.0'
+  spec.add_development_dependency 'bundler-audit', '~> 0.8.0'
   spec.add_development_dependency 'fast_jsonapi', '~> 1.5'
   spec.add_development_dependency 'loofah', '~> 2.3.1'
   spec.add_development_dependency 'factory_bot', '~> 4.11.1'


### PR DESCRIPTION
I bumped also bundler-audit to most recent one.

It turned out that rails 6.1.X specs are not passing in every ruby.
I have to dig in to obtain if we are really not compatible with rails 6.1 or just the spec is invalid.