### PR TITLE
[CVE-2020-26247] Bump nokogiri

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ defaults: &defaults
           - ./*.json
 
 jobs:
-  ruby-240:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.4
   ruby-250:
     <<: *defaults
     docker:
@@ -67,9 +63,6 @@ workflows:
   commit:
     jobs:
       - download-and-persist-cc-test-reporter
-      - ruby-240:
-          requires:
-            - download-and-persist-cc-test-reporter
       - ruby-250:
           requires:
             - download-and-persist-cc-test-reporter
@@ -85,7 +78,6 @@ workflows:
               only:
                 - master
           requires:
-            - ruby-240
             - ruby-250
             - ruby-260
             - ruby-270

--- a/jsonapi_parameters.gemspec
+++ b/jsonapi_parameters.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |spec|
   spec.license     = 'MIT'
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_runtime_dependency 'activesupport', '>= 4.1.8'
   spec.add_runtime_dependency 'actionpack', '>= 4.1.8'
 
-  spec.add_development_dependency 'nokogiri', '~> 1.10.5'
+  spec.add_development_dependency 'nokogiri', '~> 1.11'
   spec.add_development_dependency 'json', '~> 2.0'
   spec.add_development_dependency 'sqlite3', '~> 1.4'
   spec.add_development_dependency 'database_cleaner', '~> 1.7.0'

--- a/lib/jsonapi_parameters/version.rb
+++ b/lib/jsonapi_parameters/version.rb
@@ -1,5 +1,5 @@
 module JsonApi
   module Parameters
-    VERSION = '2.2.0'.freeze
+    VERSION = '2.3.0'.freeze
   end
 end


### PR DESCRIPTION
`master` is broken because of audit check that alerted about CVE-2020-26247.