### PR TITLE
Add ruby 3.0.0 and bump nokogiri

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,10 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/ruby:2.7.0
+  ruby-300:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:3.0.0
   download-and-persist-cc-test-reporter:
     docker:
         - image: circleci/ruby:2.6.0
@@ -79,6 +83,9 @@ workflows:
       - ruby-270:
           requires:
             - download-and-persist-cc-test-reporter
+      - ruby-300:
+          requires:
+            - download-and-persist-cc-test-reporter
       - upload-test-coverage:
           filters:
             branches:
@@ -89,3 +96,4 @@ workflows:
             - ruby-250
             - ruby-260
             - ruby-270
+            - ruby-300

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ defaults: &defaults
           - ./*.json
 
 jobs:
-  ruby-240:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.4
   ruby-250:
     <<: *defaults
     docker:
@@ -71,9 +67,6 @@ workflows:
   commit:
     jobs:
       - download-and-persist-cc-test-reporter
-      - ruby-240:
-          requires:
-            - download-and-persist-cc-test-reporter
       - ruby-250:
           requires:
             - download-and-persist-cc-test-reporter
@@ -92,7 +85,6 @@ workflows:
               only:
                 - master
           requires:
-            - ruby-240
             - ruby-250
             - ruby-260
             - ruby-270

--- a/jsonapi_parameters.gemspec
+++ b/jsonapi_parameters.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '>= 4.1.8'
   spec.add_runtime_dependency 'actionpack', '>= 4.1.8'
 
-  spec.add_development_dependency 'nokogiri', '~> 1.10.5'
+  spec.add_development_dependency 'nokogiri', '~> 1.11.1'
   spec.add_development_dependency 'json', '~> 2.0'
   spec.add_development_dependency 'sqlite3', '~> 1.4'
   spec.add_development_dependency 'database_cleaner', '~> 1.7.0'

--- a/jsonapi_parameters.gemspec
+++ b/jsonapi_parameters.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rubocop', '~> 0.62.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.31.0'
-  spec.add_development_dependency 'bundler-audit', '~> 0.6.0'
+  spec.add_development_dependency 'bundler-audit', '~> 0.7.0'
   spec.add_development_dependency 'fast_jsonapi', '~> 1.5'
   spec.add_development_dependency 'loofah', '~> 2.3.1'
   spec.add_development_dependency 'factory_bot', '~> 4.11.1'


### PR DESCRIPTION
I added ruby 3.0.0 to circle CI

nokogiri broke bundle-audit , so upgrade.

Bundler-audit is also updated
